### PR TITLE
Add DefaultFormat to control how Error() prints stacktrace

### DIFF
--- a/format.go
+++ b/format.go
@@ -1,0 +1,134 @@
+// Copyright 2016 Palantir Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stacktrace
+
+import (
+	"fmt"
+	"strings"
+)
+
+/*
+DefaultFormat defines the behavior of err.Error() when called on a stacktrace,
+as well as the default behavior of the "%v", "%s" and "%q" formatting
+specifiers. By default, all of these produce a full stacktrace including line
+number information. To have them produce a condensed single-line output, set
+this value to stacktrace.FormatBrief.
+
+The formatting specifier "%+s" can be used to force a full stacktrace regardless
+of the value of DefaultFormat. Similarly, the formatting specifier "%#s" can be
+used to force a brief output.
+*/
+var DefaultFormat = FormatFull
+
+// Format is the type of the two possible values of stacktrace.DefaultFormat.
+type Format int
+
+const (
+	// FormatFull means format as a full stacktrace including line number information.
+	FormatFull Format = iota
+	// FormatBrief means Format on a single line without line number information.
+	FormatBrief
+)
+
+var _ fmt.Formatter = (*stacktrace)(nil)
+
+func (st *stacktrace) Format(f fmt.State, c rune) {
+	var text string
+	if f.Flag('+') && !f.Flag('#') && c == 's' { // "%+s"
+		text = formatFull(st)
+	} else if f.Flag('#') && !f.Flag('+') && c == 's' { // "%#s"
+		text = formatBrief(st)
+	} else {
+		text = map[Format]func(*stacktrace) string{
+			FormatFull:  formatFull,
+			FormatBrief: formatBrief,
+		}[DefaultFormat](st)
+	}
+
+	formatString := "%"
+	// keep the flags recognized by fmt package
+	for _, flag := range "-+# 0" {
+		if f.Flag(int(flag)) {
+			formatString += string(flag)
+		}
+	}
+	if width, has := f.Width(); has {
+		formatString += fmt.Sprint(width)
+	}
+	if precision, has := f.Precision(); has {
+		formatString += "."
+		formatString += fmt.Sprint(precision)
+	}
+	formatString += string(c)
+	fmt.Fprintf(f, formatString, text)
+}
+
+func formatFull(st *stacktrace) string {
+	var str string
+	newline := func() {
+		if str != "" && !strings.HasSuffix(str, "\n") {
+			str += "\n"
+		}
+	}
+
+	for curr, ok := st, true; ok; curr, ok = curr.cause.(*stacktrace) {
+		str += curr.message
+
+		if curr.file != "" {
+			newline()
+			if curr.function == "" {
+				str += fmt.Sprintf(" --- at %v:%v ---", curr.file, curr.line)
+			} else {
+				str += fmt.Sprintf(" --- at %v:%v (%v) ---", curr.file, curr.line, curr.function)
+			}
+		}
+
+		if curr.cause != nil {
+			newline()
+			if cause, ok := curr.cause.(*stacktrace); !ok {
+				str += "Caused by: "
+				str += curr.cause.Error()
+			} else if cause.message != "" {
+				str += "Caused by: "
+			}
+		}
+	}
+
+	return str
+}
+
+func formatBrief(st *stacktrace) string {
+	var str string
+	concat := func(msg string) {
+		if str != "" && msg != "" {
+			str += ": "
+		}
+		str += msg
+	}
+
+	curr := st
+	for {
+		concat(curr.message)
+		if cause, ok := curr.cause.(*stacktrace); ok {
+			curr = cause
+		} else {
+			break
+		}
+	}
+	if curr.cause != nil {
+		concat(curr.cause.Error())
+	}
+	return str
+}

--- a/format_test.go
+++ b/format_test.go
@@ -1,0 +1,97 @@
+// Copyright 2016 Palantir Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stacktrace_test
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/palantir/stacktrace"
+)
+
+func TestFormat(t *testing.T) {
+	plainErr := errors.New("plain")
+	stacktraceErr := stacktrace.Propagate(plainErr, "decorated")
+	digits := regexp.MustCompile(`\d`)
+
+	for _, test := range []struct {
+		format             stacktrace.Format
+		specifier          string
+		expectedPlain      string
+		expectedStacktrace string
+	}{
+		{
+			format:             stacktrace.FormatFull,
+			specifier:          "%v",
+			expectedPlain:      "plain",
+			expectedStacktrace: "decorated\n --- at github.com/palantir/stacktrace/format_test.go:## (TestFormat) ---\nCaused by: plain",
+		},
+		{
+			format:             stacktrace.FormatFull,
+			specifier:          "%q",
+			expectedPlain:      "\"plain\"",
+			expectedStacktrace: "\"decorated\\n --- at github.com/palantir/stacktrace/format_test.go:## (TestFormat) ---\\nCaused by: plain\"",
+		},
+		{
+			format:             stacktrace.FormatFull,
+			specifier:          "%105s",
+			expectedPlain:      "                                                                                                    plain",
+			expectedStacktrace: "     decorated\n --- at github.com/palantir/stacktrace/format_test.go:## (TestFormat) ---\nCaused by: plain",
+		},
+		{
+			format:             stacktrace.FormatFull,
+			specifier:          "%#s",
+			expectedPlain:      "plain",
+			expectedStacktrace: "decorated: plain",
+		},
+		{
+			format:             stacktrace.FormatBrief,
+			specifier:          "%v",
+			expectedPlain:      "plain",
+			expectedStacktrace: "decorated: plain",
+		},
+		{
+			format:             stacktrace.FormatBrief,
+			specifier:          "%q",
+			expectedPlain:      "\"plain\"",
+			expectedStacktrace: "\"decorated: plain\"",
+		},
+		{
+			format:             stacktrace.FormatBrief,
+			specifier:          "%20s",
+			expectedPlain:      "               plain",
+			expectedStacktrace: "    decorated: plain",
+		},
+		{
+			format:             stacktrace.FormatBrief,
+			specifier:          "%+s",
+			expectedPlain:      "plain",
+			expectedStacktrace: "decorated\n --- at github.com/palantir/stacktrace/format_test.go:## (TestFormat) ---\nCaused by: plain",
+		},
+	} {
+		stacktrace.DefaultFormat = test.format
+
+		actualPlain := fmt.Sprintf(test.specifier, plainErr)
+		assert.Equal(t, test.expectedPlain, actualPlain)
+
+		actualStacktrace := fmt.Sprintf(test.specifier, stacktraceErr)
+		actualStacktrace = digits.ReplaceAllString(actualStacktrace, "#")
+		assert.Equal(t, test.expectedStacktrace, actualStacktrace)
+	}
+}

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -236,28 +236,5 @@ func shortFuncName(f *runtime.Func) string {
 }
 
 func (st *stacktrace) Error() string {
-	str := st.message
-
-	if st.file != "" {
-		if str != "" {
-			str += "\n"
-		}
-		if st.function == "" {
-			str += fmt.Sprintf(" --- at %v:%v ---", st.file, st.line)
-		} else {
-			str += fmt.Sprintf(" --- at %v:%v (%v) ---", st.file, st.line, st.function)
-		}
-	}
-
-	if st.cause != nil {
-		if str != "" {
-			str += "\n"
-		}
-		if cause, ok := st.cause.(*stacktrace); !ok || cause.message != "" {
-			str += "Caused by: "
-		}
-		str += st.cause.Error()
-	}
-
-	return str
+	return fmt.Sprint(st)
 }

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -16,6 +16,7 @@ package stacktrace_test
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -45,7 +46,9 @@ func TestMessage(t *testing.T) {
 		"Caused by: failed to start doing",
 		" --- at github.com/palantir/stacktrace/functions_for_test.go:26 (startDoing) ---",
 	}, "\n")
+	stacktrace.DefaultFormat = stacktrace.FormatFull
 	assert.Equal(t, expected, err.Error())
+	assert.Equal(t, expected, fmt.Sprint(err))
 }
 
 func TestGetCode(t *testing.T) {


### PR DESCRIPTION
See discussion on #6.