### PR TITLE
Add RootMessage function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ sudo: false
 
 language: go
 
-go: 1.6
+go: 1.13
 
 before_install:
-  - go get github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
 
 script:
   - go vet ./...
-  - $HOME/gopath/bin/golint ./...
+  - $GOPATH/bin/golint ./...
   - go test -v ./...
 
 notifications:

--- a/cause.go
+++ b/cause.go
@@ -24,3 +24,41 @@ func RootCause(err error) error {
 		err = st.cause
 	}
 }
+
+/*
+RootMessage returns message which was associated with root cause error.
+	func f(file string) error {
+		....
+		....
+		file, err := os.Open(file)
+		if err != nil {
+			return stacktrace.Propagate(err, "formatted message for user", ...specific args)
+		}
+		....
+		....
+	}
+
+	err := f("./foo/bar")
+	if err != nil {
+		err := stacktrace.RootCause(err)
+		// do something with root error
+
+		// return formatted message for user
+		showToUser(stacktrace.RootMessage(err))
+	}
+
+*/
+func RootMessage(err error) string {
+	var message string
+	for {
+		st, ok := err.(*stacktrace)
+		if !ok {
+			return message
+		}
+		if st.cause == nil {
+			return st.message
+		}
+		err = st.cause
+		message = st.message
+	}
+}

--- a/cause_test.go
+++ b/cause_test.go
@@ -46,3 +46,37 @@ func TestRootCause(t *testing.T) {
 		assert.Equal(t, test.rootCause, stacktrace.RootCause(test.err))
 	}
 }
+
+func TestRootMessage(t *testing.T) {
+	for _, test := range []struct {
+		message string
+		err     error
+	}{
+		{
+			message: "",
+			err:     nil,
+		},
+		{
+			message: "",
+			err:     customError("msg"),
+		},
+		{
+			message: "",
+			err:     errors.New("msg"),
+		},
+		{
+			message: "msg",
+			err:     stacktrace.NewError("msg"),
+		},
+		{
+			message: "msg2",
+			err:     stacktrace.Propagate(customError("msg1"), "msg2"),
+		},
+		{
+			message: "msg2",
+			err:     stacktrace.Propagate(errors.New("msg1"), "msg2"),
+		},
+	} {
+		assert.Equal(t, test.message, stacktrace.RootMessage(test.err))
+	}
+}


### PR DESCRIPTION
RootMessage returns message associated with root error in stack. This allows us to get root error message and use it to, i.e, return to user without any additional structs.