### PR TITLE
Add unwrap support

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -247,3 +247,8 @@ func (st *stacktrace) ExitCode() int {
 	}
 	return int(st.code)
 }
+
+// Unwrap returns the cause of st.
+func (st *stacktrace) Unwrap() error {
+	return st.cause
+}

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -98,3 +98,15 @@ func TestPropagateNil(t *testing.T) {
 
 	assert.Equal(t, stacktrace.NoCode, stacktrace.GetCode(err))
 }
+
+func TestUnwrap(t *testing.T) {
+	st := &stacktrace{}
+	assert.Nil(t, st.Unwrap())
+
+	err := errors.New("cause")
+	st.cause = err
+	assert.Equal(t, err, st.Unwrap())
+
+	st = Propagate(err, "propagated")
+	assert.Equal(t, err, st.Unwrap())
+}

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -100,13 +100,6 @@ func TestPropagateNil(t *testing.T) {
 }
 
 func TestUnwrap(t *testing.T) {
-	st := &stacktrace{}
-	assert.Nil(t, st.Unwrap())
-
 	err := errors.New("cause")
-	st.cause = err
-	assert.Equal(t, err, st.Unwrap())
-
-	st = Propagate(err, "propagated")
-	assert.Equal(t, err, st.Unwrap())
+	assert.Equal(t, err, unwrap(stacktrace.Propagate(err, "propagated")))
 }

--- a/unwrap_1_13_test.go
+++ b/unwrap_1_13_test.go
@@ -1,0 +1,9 @@
+// +build go1.13
+
+package stacktrace_test
+
+import "errors"
+
+func unwrap(err error) error {
+	return errors.Unwrap(err)
+}

--- a/unwrap_test.go
+++ b/unwrap_test.go
@@ -1,0 +1,11 @@
+// +build !go1.13
+
+package stacktrace_test
+
+func unwrap(err error) error {
+	t, ok := err.(interface{ Unwrap() error })
+	if !ok {
+		return nil
+	}
+	return t.Unwrap()
+}


### PR DESCRIPTION
This change adds support for `errors.Unwrap` functionality originally introduced in Golang 1.13. While the library code does not need to take multiple Golang versions into account, the testing code needs to distinguish the cases Golang  < 1.13 and Golang >= 1.13. For that, I introduced an `unwrap` helper with different implementation depending on the Golang version.